### PR TITLE
SCSS Linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ var runSequence = require('run-sequence');
 var babel = require('gulp-babel');
 var sass = require('gulp-sass');
 var eslint = require('gulp-eslint');
+var scsslint = require('gulp-scss-lint');
 
 var server = gls.new('dist/server/app.js');
 
@@ -210,15 +211,9 @@ gulp.task('serve', function() {
 gulp.task('develop', ['serve', 'watch']);
 
 /**
- * @name lint
- * @desc The lint task - Runs eslint and scsslint tasks.
+ * @name eslint
+ * @desc The eslint task - Runs eslint using specified rules.
  */
-gulp.task('lint', ['eslint']);//, 'scsslint']);
-
-/**
-* @name eslint
-* @desc The eslint task - Runs eslint using specified rules.
-*/
 gulp.task('eslint', function() {
     var eslintOptions = {
         configFile: 'config/eslint/.eslintrc',
@@ -235,18 +230,20 @@ gulp.task('eslint', function() {
         .pipe(eslint.failOnError());
 });
 
-///**
-// * @name scsslint
-// * @desc The scsslint task - Runs scsslint using specified rules.
-// */
-//gulp.task('scsslint', function() {
-//
-//});
+/**
+ * @name scsslint
+ * @desc The lint task - runs both eslint and scsslint tasks
+ */
+gulp.task('scsslint', function() {
+    gulp.src('src/**/*.scss')
+        .pipe(scsslint());
+});
 
 /**
  * @name lint
- * @desc The lint task - runs both eslint and scsslint tasks
+ * @desc The lint task - Runs eslint and scsslint tasks.
  */
+gulp.task('lint', ['eslint', 'scsslint']);
 //gulp.task('lint', gulp.parallel('eslint', 'scsslint'));
 
 /**

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-react": "^3.0.1",
     "gulp-rimraf": "^0.1.1",
     "gulp-sass": "^2.0.4",
+    "gulp-scss-lint": "^0.2.4",
     "run-sequence": "^1.1.2"
   },
   "license": "MIT"

--- a/src/client/styles/hello.scss
+++ b/src/client/styles/hello.scss
@@ -1,4 +1,4 @@
-$color: blue;
+$color: #00f;
 
 body {
   background-color: $color;


### PR DESCRIPTION
Adds support for scss linting:
-Installs the gulp-scss-lint node package (you'll need to run `npm install` after pulling)
-Adds an `scsslint` task to the gulp file
-Adds the `scsslint` task to the `lint` task (along with `eslint` - so now you can run `gulp lint` and it will run both)

Also fixes the only scss lint issue that existed

@samreaves 
